### PR TITLE
Fix reconstruction of LSTipType

### DIFF
--- a/ios/RNLivesafe.m
+++ b/ios/RNLivesafe.m
@@ -57,7 +57,7 @@ RCT_EXPORT_METHOD(registerForNotifications){
 
 // Opens LiveSafe's UI to submit new Tip. type param most be one of the TipTypes LiveSafe Provides. (getTipTypes)
 RCT_EXPORT_METHOD(submitTip: (NSDictionary* ) type){
-    LSTipType *tipType = [[LSTipType alloc] initWithTypeId: (int)[type objectForKey:@"value"]];
+    LSTipType *tipType = [[LSTipType alloc] initWithTypeId: [[type objectForKey:@"value"] intValue]];
     LSReportTipConfig *reportTipConfig = [[LSReportTipConfig alloc] initWithTipType:tipType];
     AppDelegate *delegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
 


### PR DESCRIPTION
 * LSTipType uses Swift's Int type under the hood. Since `int` is always 32 bit, this caused the reconstructed tipTypeId to be incorrect on devices with a 64 bit architecture.